### PR TITLE
style(23UG-67): устанавливает порядок импортов

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+dist-ssr
+.vscode/*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   env: {
     browser: true,
     es2020: true,

--- a/packages/client/.eslintrc.cjs
+++ b/packages/client/.eslintrc.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  plugins: ["simple-import-sort"],
+  rules: {
+    "simple-import-sort/imports": [
+      "warn",
+      {
+        groups: [
+          ["^@?\\w"],
+          ["^react"],
+          ["^(services|hooks|utils|theme)(/.*|$)"],
+          ["^(pages)(/.*|$)"],
+          ["^hoc"],
+          ["^components"],
+          ["^assets(/.*|$)"],
+          ["^\\.\\.(?!/?$)", "^\\.\\./?$"],
+          ["^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"],
+          ["^styles(/.*|$)"],
+          ["^.+\\.s?css$"],
+        ],
+      },
+    ],
+    "simple-import-sort/exports": "warn",
+  },
+};

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,7 +9,9 @@
     "lint:js": "eslint --color --ext \".js,.jsx,.ts,.tsx\" .",
     "lint:scss": "stylelint --cache --cache-location \"node_modules/.cache/stylelint/.stylelintcache\" --ignore-path .gitignore \"{**/*,*}.{css,scss}\"",
     "lint": "npm-run-all -l -p \"lint:**\"",
-    "format": "prettier --write .",
+    "format:prettier": "prettier --write .",
+    "format:imports": "npm run lint:js -- --fix",
+    "format": "npm-run-all -l -p \"format:**\"",
     "test": "jest ./"
   },
   "dependencies": {
@@ -39,6 +41,7 @@
     "@typescript-eslint/parser": "^5.35.1",
     "@vitejs/plugin-react": "^2.0.1",
     "eslint": "^8.23.0",
+    "eslint-plugin-simple-import-sort": "^10.0.0",
     "jest": "^28",
     "jest-css-modules-transform": "^4.4.2",
     "jest-environment-jsdom": "^29.0.1",

--- a/packages/client/src/components/app-footer/AppFooter.tsx
+++ b/packages/client/src/components/app-footer/AppFooter.tsx
@@ -1,4 +1,5 @@
-import { Container, Box, Typography, Link } from "@mui/material";
+import { Box, Container, Link, Typography } from "@mui/material";
+
 import { ROUTES } from "../../constants";
 
 export const AppFooter = () => {

--- a/packages/client/src/components/app-header/AppHeader.tsx
+++ b/packages/client/src/components/app-header/AppHeader.tsx
@@ -1,29 +1,28 @@
-import clsx from "clsx";
-import * as React from "react";
-import { Link, NavLink } from "react-router-dom";
+import Brightness4Icon from "@mui/icons-material/Brightness4";
+import Brightness7Icon from "@mui/icons-material/Brightness7";
 import {
   Container,
   Divider,
-  FormGroup,
   FormControlLabel,
+  FormGroup,
   Menu,
   MenuItem,
   Switch,
 } from "@mui/material";
+import clsx from "clsx";
 
-import Brightness4Icon from "@mui/icons-material/Brightness4";
-import Brightness7Icon from "@mui/icons-material/Brightness7";
-
-import { useTheme } from "theme/useTheme";
-import { Theme } from "theme/ThemeContext";
+import * as React from "react";
+import { Link, NavLink } from "react-router-dom";
 
 import { useDispatch, useSelector } from "services/hooks";
-import { authThunks, authSelect } from "services/slices/auth-slice";
+import { authSelect, authThunks } from "services/slices/auth-slice";
+import { Theme } from "theme/ThemeContext";
+import { useTheme } from "theme/useTheme";
 
 import { Picture } from "components/picture/Picture";
 
-import logo from "assets/images/logo.png?quality=75&imagetools";
 import logoWebp from "assets/images/logo.png?format=webp&quality=75&source&imagetools";
+import logo from "assets/images/logo.png?quality=75&imagetools";
 
 import { ROUTES } from "../../constants";
 

--- a/packages/client/src/components/app/App.tsx
+++ b/packages/client/src/components/app/App.tsx
@@ -1,23 +1,27 @@
 import { useEffect } from "react";
 import { Route, Routes, useLocation } from "react-router-dom";
-import GamePage from "../../pages/GamePage";
-import { useDispatch, useSelector } from "../../services/hooks";
-import { authThunks, authSelect } from "../../services/slices/auth-slice";
-import { useTheme } from "../../theme/useTheme";
+
+import { useDispatch, useSelector } from "services/hooks";
+import { authSelect, authThunks } from "services/slices/auth-slice";
+import { Theme } from "theme/ThemeContext";
+import { useTheme } from "theme/useTheme";
+
+import { ForumMessagesListPage } from "pages/ForumPage/ForumMessagesListPage";
+import { ForumThemesListPage } from "pages/ForumPage/ForumThemesListPage";
+import GamePage from "pages/GamePage";
+import GamePreparingPage from "pages/GamePreparingPage";
+import { HomePage } from "pages/HomePage/HomePage";
+import { LiderboardPage } from "pages/LiderboardPage/LiderboardPage";
+import { LoginPage } from "pages/LoginPage/LoginPage";
+import { ProfilePage } from "pages/ProfilePage/ProfilePage";
+import { RegisterPage } from "pages/RegisterPage/RegisterPage";
+
+import { AppFooter } from "components/app-footer/AppFooter";
+import { AppHeader } from "components/app-header/AppHeader";
+import { AuthPagesRoute } from "components/auth-pages-route/AuthPagesRoute";
+import { ProtectedRoute } from "components/protected-route/ProtectedRoute";
+
 import { ROUTES } from "../../constants";
-import { HomePage } from "../../pages/HomePage/HomePage";
-import { LiderboardPage } from "../../pages/LiderboardPage/LiderboardPage";
-import { AppHeader } from "../../components/app-header/AppHeader";
-import { AppFooter } from "../../components/app-footer/AppFooter";
-import { LoginPage } from "../../pages/LoginPage/LoginPage";
-import { RegisterPage } from "../../pages/RegisterPage/RegisterPage";
-import { ProfilePage } from "../../pages/ProfilePage/ProfilePage";
-import { Theme } from "../../theme/ThemeContext";
-import { ForumThemesListPage } from "../../pages/ForumPage/ForumThemesListPage";
-import { ForumMessagesListPage } from "../../pages/ForumPage/ForumMessagesListPage";
-import GamePreparingPage from "../../pages/GamePreparingPage";
-import { ProtectedRoute } from "../protected-route/ProtectedRoute";
-import { AuthPagesRoute } from "../auth-pages-route/AuthPagesRoute";
 
 function App() {
   const dispatch = useDispatch();

--- a/packages/client/src/components/auth-pages-route/AuthPagesRoute.tsx
+++ b/packages/client/src/components/auth-pages-route/AuthPagesRoute.tsx
@@ -1,7 +1,9 @@
 import { Navigate, Outlet, useLocation } from "react-router-dom";
+
+import { useSelector } from "services/hooks";
+import { authSelect } from "services/slices/auth-slice";
+
 import { ROUTES } from "../../constants";
-import { useSelector } from "../../services/hooks";
-import { authSelect } from "../../services/slices/auth-slice";
 
 export const AuthPagesRoute = () => {
   const location = useLocation();

--- a/packages/client/src/components/game-preparing/GamePreparing.tsx
+++ b/packages/client/src/components/game-preparing/GamePreparing.tsx
@@ -1,3 +1,5 @@
+import GroupsOutlinedIcon from "@mui/icons-material/GroupsOutlined";
+import PersonOutlinedIcon from "@mui/icons-material/PersonOutlined";
 import {
   Button,
   Card,
@@ -8,15 +10,17 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { FormEvent, memo, useCallback, useLayoutEffect, useState } from "react";
-import PersonOutlinedIcon from "@mui/icons-material/PersonOutlined";
-import GroupsOutlinedIcon from "@mui/icons-material/GroupsOutlined";
-import { useDispatch } from "../../services/hooks";
-import { useNavigate, useSearchParams } from "react-router-dom";
-import { ROUTES } from "../../constants";
-import gamer from "../../assets/images/gamer.png";
-import { gameSlice } from "../../services/slices/gameSlice";
 import { customAlphabet } from "nanoid";
+
+import { FormEvent, memo, useCallback, useLayoutEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+import { useDispatch } from "services/hooks";
+import { gameSlice } from "services/slices/gameSlice";
+
+import gamer from "assets/images/gamer.png";
+
+import { ROUTES } from "../../constants";
 
 const nanoid = customAlphabet("123456789", 4);
 

--- a/packages/client/src/components/game/Game.tsx
+++ b/packages/client/src/components/game/Game.tsx
@@ -1,16 +1,18 @@
 import { memo, useEffect, useRef } from "react";
-import styles from "./Game.module.scss";
-import createBackSideCard from "./utils/createBackSideCard";
-import createShuffleArrayCards from "./utils/createShuffleArrayCards";
-import setCardsAmountForGamer from "./utils/setCardsAmountForGamer";
-import createGamersPositions from "./utils/createGamersPositions";
-import generateCardsDistribution from "./utils/generateCardsDistribution";
-import createUserCards from "./utils/createUserCards";
-import { TCardsDistribution } from "./types/typeAliases";
-import createDigitCard from "./utils/createDigitCard";
+
 import { CardStatus } from "./types/enums";
-import createUNOButton from "./utils/createUNOButton";
+import { TCardsDistribution } from "./types/typeAliases";
+import createBackSideCard from "./utils/createBackSideCard";
+import createDigitCard from "./utils/createDigitCard";
+import createGamersPositions from "./utils/createGamersPositions";
 import createRightDirection from "./utils/createRightDirection";
+import createShuffleArrayCards from "./utils/createShuffleArrayCards";
+import createUNOButton from "./utils/createUNOButton";
+import createUserCards from "./utils/createUserCards";
+import generateCardsDistribution from "./utils/generateCardsDistribution";
+import setCardsAmountForGamer from "./utils/setCardsAmountForGamer";
+
+import styles from "./Game.module.scss";
 
 function Game() {
   const ref = useRef<HTMLCanvasElement>(null);

--- a/packages/client/src/components/game/utils/createGamersPositions.ts
+++ b/packages/client/src/components/game/utils/createGamersPositions.ts
@@ -1,5 +1,6 @@
 import gamer from "../../../assets/images/gamer.png";
 import { Color, Font } from "../types/enums";
+
 import setCardsAmountForGamer from "./setCardsAmountForGamer";
 
 export default function createGamersPositions(

--- a/packages/client/src/components/game/utils/createShuffleArrayCards.ts
+++ b/packages/client/src/components/game/utils/createShuffleArrayCards.ts
@@ -1,4 +1,4 @@
-import { Color, CardType, CardStatus } from "../types/enums";
+import { CardStatus, CardType, Color } from "../types/enums";
 import { TShuffleArrayCards } from "../types/typeAliases";
 
 export default function createShuffleArrayCards(gamersList: { id: string; name: string }[]) {

--- a/packages/client/src/components/game/utils/createUserCards.ts
+++ b/packages/client/src/components/game/utils/createUserCards.ts
@@ -1,5 +1,6 @@
 import { CardType } from "../types/enums";
 import { TShuffleArrayCards } from "../types/typeAliases";
+
 import createDigitCard from "./createDigitCard";
 import createOrderColorCard from "./createOrderColorCard";
 import createReverseStrokeCard from "./createReverseStrokeCard";

--- a/packages/client/src/components/leaderboard-profile/LeaderbordProfile.tsx
+++ b/packages/client/src/components/leaderboard-profile/LeaderbordProfile.tsx
@@ -1,6 +1,5 @@
-import { profilesList } from "./database";
-import * as React from "react";
 import {
+  Avatar,
   Paper,
   Table,
   TableBody,
@@ -9,9 +8,13 @@ import {
   TableHead,
   TablePagination,
   TableRow,
-  Avatar,
 } from "@mui/material";
-import { createData } from "../../utils/createDataForLeaderboard";
+
+import * as React from "react";
+
+import { createData } from "utils/createDataForLeaderboard";
+
+import { profilesList } from "./database";
 
 type LabelDisplayedRowsArgs = {
   from: number;

--- a/packages/client/src/components/protected-route/ProtectedRoute.tsx
+++ b/packages/client/src/components/protected-route/ProtectedRoute.tsx
@@ -1,7 +1,9 @@
 import { Navigate, Outlet, useLocation } from "react-router-dom";
+
+import { useSelector } from "services/hooks";
+import { authSelect } from "services/slices/auth-slice";
+
 import { ROUTES } from "../../constants";
-import { useSelector } from "../../services/hooks";
-import { authSelect } from "../../services/slices/auth-slice";
 
 export const ProtectedRoute = () => {
   const location = useLocation();

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
 import { Provider } from "react-redux";
+import { BrowserRouter } from "react-router-dom";
+
 import App from "./components/app/App";
 import { store } from "./services/store";
-import "./styles/index.scss";
 import ThemeProvider from "./theme/ThemeProvider";
+
+import "./styles/index.scss";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/packages/client/src/pages/ForumPage/ForumMessagesListPage.tsx
+++ b/packages/client/src/pages/ForumPage/ForumMessagesListPage.tsx
@@ -1,12 +1,16 @@
+import DeleteIcon from "@mui/icons-material/Delete";
+import { Avatar, Button, Container, TextField } from "@mui/material";
+
+import React, { useEffect, useState } from "react";
+import { NavLink, useParams } from "react-router-dom";
+
+import { ROUTES } from "../../constants";
+
+import { currentUserData, forumData } from "./data/data";
+import { MessageItem } from "./MessageItem/MessageItem";
+
 import styles from "./ForumPage.module.scss";
 import stylesMessageItem from "./MessageItem/MessageItem.module.scss";
-import React, { useState, useEffect } from "react";
-import { NavLink, useParams } from "react-router-dom";
-import { MessageItem } from "./MessageItem/MessageItem";
-import { Avatar, Button, Container, TextField } from "@mui/material";
-import DeleteIcon from "@mui/icons-material/Delete";
-import { currentUserData, forumData } from "./data/data";
-import { ROUTES } from "../../constants";
 
 export const ForumMessagesListPage: React.FC = () => {
   const [text, setText] = useState("");

--- a/packages/client/src/pages/ForumPage/ForumThemesListPage.tsx
+++ b/packages/client/src/pages/ForumPage/ForumThemesListPage.tsx
@@ -1,8 +1,11 @@
-import styles from "./ForumPage.module.scss";
-import { ThemeItem } from "./ThemeItem/ThemeItem";
-import React, { useState, useEffect } from "react";
 import { Button, Container, TextField } from "@mui/material";
+
+import React, { useEffect, useState } from "react";
+
 import { forumData } from "./data/data";
+import { ThemeItem } from "./ThemeItem/ThemeItem";
+
+import styles from "./ForumPage.module.scss";
 
 export const ForumThemesListPage: React.FC = () => {
   const [title, setTitle] = useState("");

--- a/packages/client/src/pages/ForumPage/MessageItem/MessageItem.tsx
+++ b/packages/client/src/pages/ForumPage/MessageItem/MessageItem.tsx
@@ -1,8 +1,11 @@
-import styles from "./MessageItem.module.scss";
-import { MessageType } from "../types/types";
-import React from "react";
 import { Avatar } from "@mui/material";
+
+import React from "react";
+
 import { timeOptions } from "../helpers/timeOptions";
+import { MessageType } from "../types/types";
+
+import styles from "./MessageItem.module.scss";
 
 type PropsType = {
   messageData: MessageType;

--- a/packages/client/src/pages/ForumPage/ThemeItem/ThemeItem.tsx
+++ b/packages/client/src/pages/ForumPage/ThemeItem/ThemeItem.tsx
@@ -1,10 +1,12 @@
-import styles from "./ThemeItem.module.scss";
 import React from "react";
-import { timeOptions } from "../helpers/timeOptions";
 import { NavLink } from "react-router-dom";
-import { ThemeType } from "../types/types";
-import { ending } from "../helpers/ending";
+
 import { ROUTES } from "../../../constants";
+import { ending } from "../helpers/ending";
+import { timeOptions } from "../helpers/timeOptions";
+import { ThemeType } from "../types/types";
+
+import styles from "./ThemeItem.module.scss";
 
 type PropsType = ThemeType;
 

--- a/packages/client/src/pages/GamePage.tsx
+++ b/packages/client/src/pages/GamePage.tsx
@@ -1,4 +1,4 @@
-import Game from "../components/game/Game";
+import Game from "components/game/Game";
 
 function GamePage() {
   return <Game />;

--- a/packages/client/src/pages/GamePreparingPage.tsx
+++ b/packages/client/src/pages/GamePreparingPage.tsx
@@ -1,4 +1,4 @@
-import GamePreparing from "../components/game-preparing/GamePreparing";
+import GamePreparing from "components/game-preparing/GamePreparing";
 
 function GamePreparingPage() {
   return <GamePreparing />;

--- a/packages/client/src/pages/HomePage/HomePage.tsx
+++ b/packages/client/src/pages/HomePage/HomePage.tsx
@@ -1,23 +1,24 @@
-import React from "react";
-import { Container, Button, Grid, Paper, Card, CardContent, Typography } from "@mui/material";
+import { Button, Card, CardContent, Container, Grid, Paper, Typography } from "@mui/material";
 
-import { useTheme } from "theme/useTheme";
+import React from "react";
+
 import { Theme } from "theme/ThemeContext";
+import { useTheme } from "theme/useTheme";
 
 import { Picture } from "components/picture/Picture";
 
-import promoBg from "assets/images/promo_bg.jpg?quality=75&imagetools";
-import promoBgWebp from "assets/images/promo_bg.jpg?format=webp&quality=75&source&imagetools";
-import advantage1 from "assets/images/advantage-1.png?quality=75&imagetools";
 import advantage1Webp from "assets/images/advantage-1.png?format=webp&quality=75&source&imagetools";
-import advantage2 from "assets/images/advantage-2.png?quality=75&imagetools";
+import advantage1 from "assets/images/advantage-1.png?quality=75&imagetools";
 import advantage2Webp from "assets/images/advantage-2.png?format=webp&quality=75&source&imagetools";
-import advantage3 from "assets/images/advantage-3.png?quality=75&imagetools";
+import advantage2 from "assets/images/advantage-2.png?quality=75&imagetools";
 import advantage3Webp from "assets/images/advantage-3.png?format=webp&quality=75&source&imagetools";
-import advantage4 from "assets/images/advantage-4.png?quality=75&imagetools";
+import advantage3 from "assets/images/advantage-3.png?quality=75&imagetools";
 import advantage4Webp from "assets/images/advantage-4.png?format=webp&quality=75&source&imagetools";
-import advantage5 from "assets/images/advantage-5.png?quality=75&imagetools";
+import advantage4 from "assets/images/advantage-4.png?quality=75&imagetools";
 import advantage5Webp from "assets/images/advantage-5.png?format=webp&quality=75&source&imagetools";
+import advantage5 from "assets/images/advantage-5.png?quality=75&imagetools";
+import promoBgWebp from "assets/images/promo_bg.jpg?format=webp&quality=75&source&imagetools";
+import promoBg from "assets/images/promo_bg.jpg?quality=75&imagetools";
 
 import { ROUTES } from "../../constants";
 

--- a/packages/client/src/pages/LiderboardPage/LiderboardPage.tsx
+++ b/packages/client/src/pages/LiderboardPage/LiderboardPage.tsx
@@ -1,9 +1,9 @@
 import { Container } from "@mui/material";
-import { Stack, Button, Typography } from "@mui/material";
+import { Button, Stack, Typography } from "@mui/material";
+
+import { LeaderboardProfile } from "components/leaderboard-profile/LeaderbordProfile";
 
 import styles from "./LiderboardPage.module.scss";
-
-import { LeaderboardProfile } from "../../components/leaderboard-profile/LeaderbordProfile";
 
 export const LiderboardPage = () => {
   const handleFilter = (e: React.MouseEvent<HTMLElement>): void => {

--- a/packages/client/src/pages/LoginPage/LoginPage.tsx
+++ b/packages/client/src/pages/LoginPage/LoginPage.tsx
@@ -1,15 +1,14 @@
-import { Container, Link, Typography, Button, Stack, TextField, Box } from "@mui/material";
-import styles from "./LoginPage.module.scss";
+import { Box, Button, Container, Link, Stack, TextField, Typography } from "@mui/material";
+
+import { Controller, SubmitHandler, useForm } from "react-hook-form";
+
+import { useDispatch, useSelector } from "services/hooks";
+import { authSelect, authThunks } from "services/slices/auth-slice";
+import { InputNames, REQUIRED_MESSAGE, validationTemplate } from "utils/validation/validation";
+
 import { ROUTES } from "../../constants";
 
-import { useForm, Controller, SubmitHandler } from "react-hook-form";
-import { useDispatch, useSelector } from "../../services/hooks";
-import {
-  InputNames,
-  REQUIRED_MESSAGE,
-  validationTemplate,
-} from "../../utils/validation/validation";
-import { authSelect, authThunks } from "../../services/slices/auth-slice";
+import styles from "./LoginPage.module.scss";
 
 type TFormInput = {
   login: string;

--- a/packages/client/src/pages/ProfilePage/ProfilePage.tsx
+++ b/packages/client/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,4 +1,5 @@
 import { Container } from "@mui/material";
+
 import styles from "./ProfilePage.module.scss";
 
 export const ProfilePage = () => {

--- a/packages/client/src/pages/RegisterPage/RegisterPage.tsx
+++ b/packages/client/src/pages/RegisterPage/RegisterPage.tsx
@@ -1,15 +1,18 @@
-import { useRef } from "react";
-import { Container, Typography, Stack, TextField, Button, Link } from "@mui/material";
-import styles from "./RegisterPage.module.scss";
-import { ROUTES } from "../../constants";
+import { Button, Container, Link, Stack, TextField, Typography } from "@mui/material";
 
-import { Controller, useForm, SubmitHandler } from "react-hook-form";
+import { useRef } from "react";
+import { Controller, SubmitHandler, useForm } from "react-hook-form";
+
 import {
   ERROR_MESSAGE,
   InputNames,
   REQUIRED_MESSAGE,
   validationTemplate,
-} from "../../utils/validation/validation";
+} from "utils/validation/validation";
+
+import { ROUTES } from "../../constants";
+
+import styles from "./RegisterPage.module.scss";
 
 type TFormInput = {
   email: string;

--- a/packages/client/src/services/api/authApi.ts
+++ b/packages/client/src/services/api/authApi.ts
@@ -1,6 +1,6 @@
-import { LoginRequestData, User, UserDTO } from "./types";
 import { request } from "./apiRequest";
 import { transformUser } from "./transformers";
+import { LoginRequestData, User, UserDTO } from "./types";
 
 export const authAPI = {
   login: (data: LoginRequestData): Promise<"OK"> =>

--- a/packages/client/src/services/reducers.ts
+++ b/packages/client/src/services/reducers.ts
@@ -1,4 +1,5 @@
 import { combineReducers } from "redux";
+
 import { authSlice } from "./slices/auth-slice";
 import { gameSlice } from "./slices/gameSlice";
 

--- a/packages/client/src/services/slices/auth-slice.ts
+++ b/packages/client/src/services/slices/auth-slice.ts
@@ -1,9 +1,8 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
-import type { RootState } from "../store";
-
 import { authAPI } from "../api/authApi";
 import { LoginRequestData, User } from "../api/types";
+import type { RootState } from "../store";
 
 type AuthState = {
   user: User | null;

--- a/packages/client/src/services/slices/gameSlice.ts
+++ b/packages/client/src/services/slices/gameSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
 import { RootState } from "../store";
 
 type TState = {

--- a/packages/client/src/services/store.ts
+++ b/packages/client/src/services/store.ts
@@ -1,4 +1,5 @@
 import { configureStore } from "@reduxjs/toolkit";
+
 import { rootReducer } from "./reducers";
 
 export const store = configureStore({

--- a/packages/client/src/theme/ThemeProvider.tsx
+++ b/packages/client/src/theme/ThemeProvider.tsx
@@ -1,9 +1,11 @@
+import { createTheme, ThemeProvider as ThemeProviderMui } from "@mui/material/styles";
+
 import React, { useMemo, useState } from "react";
-import { LOCAL_STORAGE_THEME_KEY, Theme, ThemeContext } from "./ThemeContext";
-import { ThemeProvider as ThemeProviderMui, createTheme } from "@mui/material/styles";
-import { muiPallete, setGlobalStyles } from "./muiPallete";
+
 import { muiComponents } from "./muiComponents";
+import { muiPallete, setGlobalStyles } from "./muiPallete";
 import { muiTypography } from "./muiTypography";
+import { LOCAL_STORAGE_THEME_KEY, Theme, ThemeContext } from "./ThemeContext";
 
 const defaultTheme = (localStorage.getItem(LOCAL_STORAGE_THEME_KEY) as Theme) || Theme.DARK;
 

--- a/packages/client/src/theme/muiComponents.tsx
+++ b/packages/client/src/theme/muiComponents.tsx
@@ -1,6 +1,8 @@
+import { LinkProps } from "@mui/material/Link";
+
 import { forwardRef } from "react";
 import { Link as RouterLink, LinkProps as RouterLinkProps } from "react-router-dom";
-import { LinkProps } from "@mui/material/Link";
+
 import { muiPallete } from "./muiPallete";
 import { Theme } from "./ThemeContext";
 

--- a/packages/client/src/theme/muiPallete.tsx
+++ b/packages/client/src/theme/muiPallete.tsx
@@ -1,4 +1,5 @@
 import { GlobalStyles, Theme as ThemeMui } from "@mui/material";
+
 import { Theme } from "./ThemeContext";
 
 export const muiPallete = (mode: Theme) => {

--- a/packages/client/src/theme/useTheme.ts
+++ b/packages/client/src/theme/useTheme.ts
@@ -1,5 +1,6 @@
-import { LOCAL_STORAGE_THEME_KEY, Theme, ThemeContext } from "./ThemeContext";
 import { useContext } from "react";
+
+import { LOCAL_STORAGE_THEME_KEY, Theme, ThemeContext } from "./ThemeContext";
 
 type UseThemeResult = {
   toggleTheme: () => void;

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,7 +1,7 @@
-import path from "path";
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import dotenv from "dotenv";
+import path from "path";
+import { defineConfig } from "vite";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - нет типов "@types/vite-imagetools"
 import { imagetools } from "vite-imagetools";
@@ -17,6 +17,7 @@ export default defineConfig({
       services: path.resolve(__dirname, "src", "services"),
       styles: path.resolve(__dirname, "src", "styles"),
       theme: path.resolve(__dirname, "src", "theme"),
+      utils: path.resolve(__dirname, "src", "utils"),
     },
   },
   server: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4171,6 +4171,11 @@ eslint-config-prettier@^8.5.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
 
+eslint-plugin-simple-import-sort@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz#cc4ceaa81ba73252427062705b64321946f61351"
+  integrity sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"


### PR DESCRIPTION
### Какую задачу решаем

Сейчас у нас хаотичный порядок импортов, в котором сложно ориентироваться.
Есть предложение добавить автосортировку импортов (работает при коммите) в следующем порядке;
- импорты из `node_modules`
- `react-...`
- `services`, `hooks`, `utils` , `theme`
- `pages`
- `hoc`
- `components`
- `assets`
- относительные импорты `.ts`
- импорты стилей
