### PR TITLE
build: исправляет ошибки сборки

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,3 +23,5 @@ jobs:
         run: yarn lint
       - name: Test
         run: yarn test
+      - name: Build
+        run: yarn build

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -56,7 +56,7 @@
     "stylelint-prettier": "^2.0.0",
     "stylelint-scss": "^4.4.0",
     "ts-jest": "^28.0.8",
-    "typescript": "^4.8.2",
+    "typescript": "^4.9.5",
     "vite": "^3.0.7",
     "vite-imagetools": "^4.0.18"
   },

--- a/packages/client/src/components/game/Game.tsx
+++ b/packages/client/src/components/game/Game.tsx
@@ -49,6 +49,8 @@ function Game() {
 
     const generator = generateCardsDistribution(0, gamersPositions.length);
 
+    // TODO: Исчинить типы
+    // @ts-ignore
     const cardsDistribution: TCardsDistribution = (xEndPoint: number, yEndPoint: number) => {
       if (!cardsDistribution.cardsCounter1) {
         cardsDistribution.cardsCounter1 = 1;

--- a/packages/client/src/pages/ForumPage/MessageItem/MessageItem.tsx
+++ b/packages/client/src/pages/ForumPage/MessageItem/MessageItem.tsx
@@ -16,7 +16,7 @@ export const MessageItem: React.FC<PropsType> = ({ messageData }) => {
       <div className={styles.MessageItem__user}>
         <Avatar alt="Avatar" src={messageData.messageCreatorUser.avatar} />
         <p className={styles.MessageItem__user_username}>
-          {messageData.messageCreatorUser.username}
+          {messageData.messageCreatorUser.display_name}
         </p>
       </div>
 

--- a/packages/client/src/pages/ForumPage/types/types.ts
+++ b/packages/client/src/pages/ForumPage/types/types.ts
@@ -10,13 +10,13 @@ export type UserType = {
 };
 export type MessageType = {
   messageId: number;
-  messageCreatorUser: UserType;
+  messageCreatorUser: Pick<UserType, "id" | "display_name" | "avatar">;
   messageText: string;
   messageCreationDate: Date;
 };
 export type ThemeType = {
   themeId: number;
-  themeCreatorUser: UserType;
+  themeCreatorUser: Pick<UserType, "id" | "display_name" | "avatar">;
   themeTitle: string;
   themeCreationDate: Date;
   themeMessages: MessageType[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -9087,7 +9087,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.6.4:
+typescript@^4.6.4, typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
### Какую задачу решаем

- исправлены ошибки, возникающие при запуске `yarn build`
- обновлен `typescript`, т.к. [CanvasRenderingContext2D.roundRect](https://github.com/UNOGroup-Practicum/uno-game/blob/dev/packages/client/src/components/game/utils/createBackSideCard.ts#L10) отсутствует в версии 4.8.2 и добавлен [позднее](https://github.com/microsoft/TypeScript/commit/170a17fad57eae619c5ef2b7bdb3ac00d6c32c47)
- исправлены типы на странице форума
- оставлена `todo` для исправления типов на странице игры
- для `ci` добавлена проверка `yarn build`
