### PR TITLE
test(23UG-69): добавляет тесты

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,4 +4,4 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=postgres
 POSTGRES_PORT=5432
-VITE_API_ENDPOINT=https://ya-praktikum.tech/api/v2
+API_ENDPOINT=https://ya-praktikum.tech/api/v2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,6 +19,8 @@ jobs:
         run: yarn
       - name: Initialize
         run: yarn lerna bootstrap
+      - name: Create .env file
+        run: node init.mjs
       - name: Lint
         run: yarn lint
       - name: Test

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev:server": "lerna run dev --scope=server",
     "dev": "lerna run dev",
     "test": "lerna run test",
+    "test:watch": "lerna run test:watch",
     "lint": "lerna run lint",
     "format": "lerna run format",
     "preview": "lerna run preview"

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -4,11 +4,16 @@ dotenv.config();
 export default {
   preset: "ts-jest",
   testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["<rootDir>/src/__tests__/setup.ts"],
   testMatch: ["<rootDir>/src/**/*.test.{ts,tsx}"],
   globals: {
     __SERVER_PORT__: process.env.SERVER_PORT,
+    __API_ENDPOINT__: process.env.API_ENDPOINT,
   },
   transform: {
     ".+\\.(css|styl|less|sass|scss)$": "jest-css-modules-transform",
+  },
+  moduleNameMapper: {
+    "^__tests__(.*)$": "<rootDir>/src/__tests__$1",
   },
 };

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -14,7 +14,14 @@ export default {
     ".+\\.(css|styl|less|sass|scss)$": "jest-css-modules-transform",
   },
   moduleNameMapper: {
+    ".+\\.(svg|png|jpg|jpeg|webp)": "identity-obj-proxy",
     "^__tests__(.*)$": "<rootDir>/src/__tests__$1",
     "^services(.*)$": "<rootDir>/src/services$1",
+    "^hooks(.*)$": "<rootDir>/src/hooks$1",
+    "^utils(.*)$": "<rootDir>/src/utils$1",
+    "^theme(.*)$": "<rootDir>/src/theme$1",
+    "^pages(.*)$": "<rootDir>/src/pages$1",
+    "^hoc(.*)$": "<rootDir>/src/hoc$1",
+    "^components(.*)$": "<rootDir>/src/components$1",
   },
 };

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -15,5 +15,6 @@ export default {
   },
   moduleNameMapper: {
     "^__tests__(.*)$": "<rootDir>/src/__tests__$1",
+    "^services(.*)$": "<rootDir>/src/services$1",
   },
 };

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -24,4 +24,14 @@ export default {
     "^hoc(.*)$": "<rootDir>/src/hoc$1",
     "^components(.*)$": "<rootDir>/src/components$1",
   },
+  collectCoverageFrom: ["src/**/*.{ts,tsx}"],
+  coveragePathIgnorePatterns: [
+    "node_modules",
+    "__tests__",
+    ".module.ts",
+    ".d.ts",
+    "<rootDir>/src/main.ts",
+    "<rootDir>/src/utils/registerServiceWorker.ts",
+  ],
+  coverageDirectory: "<rootDir>/node_modules/.coverage/",
 };

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,8 +12,10 @@
     "format:prettier": "prettier --write .",
     "format:imports": "npm run lint:js -- --fix",
     "format": "npm-run-all -l -p \"format:**\"",
-    "test:watch": "npm run test -- --watch",
-    "test": "jest ./"
+    "test:watch": "npm run test:only -- --watch",
+    "test:only": "jest ./",
+    "test:coverage": "npm run test:only -- --coverage",
+    "test": "npm run test:coverage"
   },
   "dependencies": {
     "@emotion/react": "^11.10.6",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^13.3.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^28.1.8",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
@@ -44,6 +45,7 @@
     "@vitejs/plugin-react": "^2.0.1",
     "eslint": "^8.23.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^28",
     "jest-css-modules-transform": "^4.4.2",
     "jest-environment-jsdom": "^29.0.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,6 +12,7 @@
     "format:prettier": "prettier --write .",
     "format:imports": "npm run lint:js -- --fix",
     "format": "npm-run-all -l -p \"format:**\"",
+    "test:watch": "npm run test -- --watch",
     "test": "jest ./"
   },
   "dependencies": {
@@ -37,6 +38,7 @@
     "@types/jest": "^28.1.8",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
+    "@types/redux-mock-store": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^5.35.1",
     "@typescript-eslint/parser": "^5.35.1",
     "@vitejs/plugin-react": "^2.0.1",
@@ -46,8 +48,10 @@
     "jest-css-modules-transform": "^4.4.2",
     "jest-environment-jsdom": "^29.0.1",
     "lefthook": "^1.1.1",
+    "msw": "^1.2.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
+    "redux-mock-store": "^1.5.4",
     "sass": "^1.58.3",
     "stylelint": "^15.2.0",
     "stylelint-config-clean-order": "^5.0.0",

--- a/packages/client/src/__tests__/api-mock.ts
+++ b/packages/client/src/__tests__/api-mock.ts
@@ -5,7 +5,7 @@ import { LoginRequestData } from "services/api/types";
 
 import { mainUser } from "./fixtures";
 
-const requestUrl = (endPoint: string) => `${process.env.API_ENDPOINT}/${endPoint}`;
+export const requestUrl = (endPoint: string) => `${process.env.API_ENDPOINT}/${endPoint}`;
 
 const handlers = [
   rest.get(requestUrl("auth/user"), (_req, res, ctx) =>

--- a/packages/client/src/__tests__/api-mock.ts
+++ b/packages/client/src/__tests__/api-mock.ts
@@ -1,0 +1,28 @@
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+
+import { LoginRequestData } from "services/api/types";
+
+import { mainUser } from "./fixtures";
+
+const requestUrl = (endPoint: string) => `${process.env.API_ENDPOINT}/${endPoint}`;
+
+const handlers = [
+  rest.get(requestUrl("auth/user"), (_req, res, ctx) =>
+    res(ctx.delay(10), ctx.status(200), ctx.json(mainUser))
+  ),
+
+  rest.post(requestUrl("auth/signin"), async (_req, res, ctx) => {
+    const { login } = (await _req.json()) as LoginRequestData;
+
+    return login === "valid"
+      ? res(ctx.delay(10), ctx.status(200), ctx.text("OK"))
+      : res(ctx.delay(10), ctx.status(401), ctx.json({ reason: "Login or password is incorrect" }));
+  }),
+
+  rest.post(requestUrl("auth/logout"), (_req, res, ctx) =>
+    res(ctx.delay(10), ctx.status(200), ctx.text("OK"))
+  ),
+];
+
+export const server = setupServer(...handlers);

--- a/packages/client/src/__tests__/fixtures.ts
+++ b/packages/client/src/__tests__/fixtures.ts
@@ -1,0 +1,12 @@
+import { UserDTO } from "services/api/types";
+
+export const mainUser: UserDTO = {
+  id: 3094,
+  login: "vasya",
+  email: "vasya@vasya.ru",
+  first_name: "Вася",
+  second_name: "Василек",
+  display_name: "Вася Василек",
+  phone: "89137909090",
+  avatar: "/d66cf98f-05dc-49ba-8d2b-c1db0c5888c3/761d694b-39b5-4dee-ab15-78a2bf05461d_12.png",
+};

--- a/packages/client/src/__tests__/fixtures.tsx
+++ b/packages/client/src/__tests__/fixtures.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import { UserDTO } from "services/api/types";
 
 export const mainUser: UserDTO = {
@@ -9,4 +11,17 @@ export const mainUser: UserDTO = {
   display_name: "Вася Василек",
   phone: "89137909090",
   avatar: "/d66cf98f-05dc-49ba-8d2b-c1db0c5888c3/761d694b-39b5-4dee-ab15-78a2bf05461d_12.png",
+};
+
+export const ValidComponent: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <div data-testid="valid-component">
+    <p>Valid component</p>
+    {children}
+  </div>
+);
+
+export const InValidComponent = () => {
+  const error = new Error("test error");
+
+  return error;
 };

--- a/packages/client/src/__tests__/setup.ts
+++ b/packages/client/src/__tests__/setup.ts
@@ -1,0 +1,5 @@
+import { server } from "./api-mock";
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/packages/client/src/__tests__/utils.ts
+++ b/packages/client/src/__tests__/utils.ts
@@ -1,0 +1,9 @@
+export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Удаляем поле meta из результатов, т.к. там requestId отличается, а нам важны только type и payload
+export const withoutMetaKey = (arr: Record<"meta" | "payload" | "type", unknown>[]) => {
+  return arr.map((obj) => ({
+    payload: obj.payload,
+    type: obj.type,
+  }));
+};

--- a/packages/client/src/__tests__/utils.ts
+++ b/packages/client/src/__tests__/utils.ts
@@ -1,9 +1,0 @@
-export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-// Удаляем поле meta из результатов, т.к. там requestId отличается, а нам важны только type и payload
-export const withoutMetaKey = (arr: Record<"meta" | "payload" | "type", unknown>[]) => {
-  return arr.map((obj) => ({
-    payload: obj.payload,
-    type: obj.type,
-  }));
-};

--- a/packages/client/src/__tests__/utils.tsx
+++ b/packages/client/src/__tests__/utils.tsx
@@ -1,0 +1,54 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import React from "react";
+import { Provider } from "react-redux";
+import { BrowserRouter } from "react-router-dom";
+
+import { rootReducer } from "services/reducers";
+import ThemeProvider from "theme/ThemeProvider";
+
+type PreloadedState = Partial<typeof rootReducer>;
+
+type RenderWithRouter = {
+  route?: string;
+  preloadedState?: PreloadedState;
+};
+
+export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Удаляем поле meta из результатов, т.к. там requestId отличается, а нам важны только type и payload
+export const withoutMetaKey = (arr: Record<"meta" | "payload" | "type", unknown>[]) => {
+  return arr.map((obj) => ({
+    payload: obj.payload,
+    type: obj.type,
+  }));
+};
+
+function makeStore(preloadedState: PreloadedState) {
+  return configureStore({
+    reducer: rootReducer,
+    preloadedState,
+  });
+}
+
+export const renderWithRouter = (
+  ui: React.ReactElement,
+  { route = "/", preloadedState = {} }: RenderWithRouter = {}
+) => {
+  const store = makeStore(preloadedState);
+  window.history.pushState({}, "Test page", route);
+
+  return {
+    user: userEvent.setup(),
+    ...render(
+      <Provider store={store}>
+        <ThemeProvider>{ui}</ThemeProvider>
+      </Provider>,
+      {
+        wrapper: BrowserRouter,
+      }
+    ),
+  };
+};

--- a/packages/client/src/client.d.ts
+++ b/packages/client/src/client.d.ts
@@ -1,8 +1,10 @@
 import type { PictureSource } from "./components/picture/Picture";
 
-declare const __SERVER_PORT__: number;
-
 declare global {
+  export declare const __SERVER_PORT__: number;
+
+  export declare const __API_ENDPOINT__: string;
+
   export declare module "*&source&imagetools" {
     const src: PictureSource[];
     export default src;

--- a/packages/client/src/components/app-header/AppHeader.tsx
+++ b/packages/client/src/components/app-header/AppHeader.tsx
@@ -89,7 +89,11 @@ export const AppHeader = () => {
                 </NavLink>
               ) : (
                 <>
-                  <button className={styles.menu__link} onClick={handleClick}>
+                  <button
+                    className={styles.menu__link}
+                    onClick={handleClick}
+                    data-testid="button-name"
+                  >
                     {user.firstName}
                   </button>
                   <Menu

--- a/packages/client/src/components/app/App.test.tsx
+++ b/packages/client/src/components/app/App.test.tsx
@@ -1,0 +1,90 @@
+import { requestUrl, server } from "__tests__/api-mock";
+import { mainUser } from "__tests__/fixtures";
+import { renderWithRouter } from "__tests__/utils";
+import { screen } from "@testing-library/react";
+import { rest } from "msw";
+
+import { initialState as authInitialState } from "services/slices/auth-slice";
+
+import { ROUTES } from "../../constants";
+
+import App from "./App";
+
+describe("Components/App", () => {
+  it("should render HomePage", async () => {
+    renderWithRouter(<App />);
+
+    expect(screen.getByTestId("page-home")).toBeDefined();
+  });
+
+  it("should go to the LoginPage", async () => {
+    server.use(
+      rest.get(requestUrl("auth/user"), (_req, res, ctx) =>
+        res.once(ctx.status(401), ctx.json({ reason: "Cookie is not valid" }))
+      )
+    );
+    const { user } = renderWithRouter(<App />, {
+      preloadedState: { auth: { ...authInitialState } },
+    });
+
+    await user.click(screen.getByText("Вход"));
+
+    expect(screen.getByTestId("page-login")).toBeDefined();
+  });
+
+  it("should go to the RegisterPage from LoginPage", async () => {
+    server.use(
+      rest.get(requestUrl("auth/user"), (_req, res, ctx) =>
+        res.once(ctx.status(401), ctx.json({ reason: "Cookie is not valid" }))
+      )
+    );
+    const { user } = renderWithRouter(<App />, {
+      route: ROUTES.signIn.path,
+      preloadedState: { auth: { ...authInitialState } },
+    });
+
+    await user.click(screen.getByText("Нет аккаунта?"));
+
+    expect(screen.getByTestId("page-register")).toBeDefined();
+  });
+
+  it("should go to the RulesPage", async () => {
+    const { user } = renderWithRouter(<App />);
+
+    await user.click(screen.getByText("Правила"));
+
+    expect(screen.getByTestId("page-rules")).toBeDefined();
+  });
+
+  it("should go to the ForumPage", async () => {
+    const { user } = renderWithRouter(<App />, {
+      preloadedState: { auth: { ...authInitialState, user: mainUser } },
+    });
+
+    await user.click(screen.getByText("Форум"));
+
+    expect(screen.getByTestId("page-forum-main")).toBeDefined();
+  });
+
+  it("should go to the LeaderboardPage", async () => {
+    const { user } = renderWithRouter(<App />, {
+      preloadedState: { auth: { ...authInitialState, user: mainUser } },
+    });
+
+    await user.click(screen.getByTestId("button-name"));
+    await user.click(screen.getByText("Лидербоард"));
+
+    expect(screen.getByTestId("page-leaderboard")).toBeDefined();
+  });
+
+  it("should go to the ProfilePage", async () => {
+    const { user } = renderWithRouter(<App />, {
+      preloadedState: { auth: { ...authInitialState, user: mainUser } },
+    });
+
+    await user.click(screen.getByTestId("button-name"));
+    await user.click(screen.getByText("Профиль"));
+
+    expect(screen.getByTestId("page-profile")).toBeDefined();
+  });
+});

--- a/packages/client/src/components/error-boundary/ErrorBoundary.test.tsx
+++ b/packages/client/src/components/error-boundary/ErrorBoundary.test.tsx
@@ -1,0 +1,70 @@
+import { InValidComponent, ValidComponent } from "__tests__/fixtures";
+import { renderWithRouter } from "__tests__/utils";
+import { screen } from "@testing-library/react";
+
+import { ErrorBoundary } from "./ErrorBoundary";
+
+describe("Components/ErrorBoundary", () => {
+  it("should render with valid component", async () => {
+    renderWithRouter(
+      <ErrorBoundary>
+        <ValidComponent />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByTestId("valid-component")).toBeDefined();
+  });
+
+  it("should render default fallback with invalid component", async () => {
+    const consoleErrorMock = jest.spyOn(console, "error").mockImplementation();
+
+    renderWithRouter(
+      <ErrorBoundary>
+        {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+        {/* @ts-ignore */}
+        <InValidComponent />
+      </ErrorBoundary>
+    );
+
+    expect(console.error).toBeCalled();
+    expect(screen.getByTestId("error-boundary-default")).toBeDefined();
+
+    consoleErrorMock.mockRestore();
+  });
+
+  it("should render custom fallback with invalid component", async () => {
+    const consoleErrorMock = jest.spyOn(console, "error").mockImplementation();
+    const customFallback = <div data-testid="custom-fallback">Custom fallback</div>;
+
+    renderWithRouter(
+      <ErrorBoundary fallback={customFallback}>
+        {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+        {/* @ts-ignore */}
+        <InValidComponent />
+      </ErrorBoundary>
+    );
+
+    expect(console.error).toBeCalled();
+    expect(screen.getByTestId("custom-fallback")).toBeDefined();
+
+    consoleErrorMock.mockRestore();
+  });
+
+  it("should render custom fallback with invalid component", async () => {
+    const consoleErrorMock = jest.spyOn(console, "error").mockImplementation();
+    const Fallback = () => <div data-testid="fallback-component">fallback-component</div>;
+
+    renderWithRouter(
+      <ErrorBoundary FallbackComponent={Fallback}>
+        {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+        {/* @ts-ignore */}
+        <InValidComponent />
+      </ErrorBoundary>
+    );
+
+    expect(console.error).toBeCalled();
+    expect(screen.getByTestId("fallback-component")).toBeDefined();
+
+    consoleErrorMock.mockRestore();
+  });
+});

--- a/packages/client/src/components/error-boundary/ErrorBoundary.tsx
+++ b/packages/client/src/components/error-boundary/ErrorBoundary.tsx
@@ -51,7 +51,12 @@ export class ErrorBoundary extends Component<
       }
 
       return (
-        <Typography variant="caption" align="center" padding={1}>
+        <Typography
+          variant="caption"
+          align="center"
+          padding={1}
+          data-testid="error-boundary-default"
+        >
           Не удалось загрузить...
         </Typography>
       );

--- a/packages/client/src/components/game-preparing/GamePreparing.tsx
+++ b/packages/client/src/components/game-preparing/GamePreparing.tsx
@@ -10,7 +10,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { customAlphabet } from "nanoid";
+import { nanoid } from "@reduxjs/toolkit";
 
 import { FormEvent, memo, useCallback, useLayoutEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -21,8 +21,6 @@ import { gameSlice } from "services/slices/gameSlice";
 import gamer from "assets/images/gamer.png";
 
 import { ROUTES } from "../../constants";
-
-const nanoid = customAlphabet("123456789", 4);
 
 function GamePreparing() {
   const [isWithFriendsCardClicked, setIsWithFriendsCardClicked] = useState<boolean>(false);
@@ -39,7 +37,7 @@ function GamePreparing() {
     } else if (searchParams.get("prestart") === "2") {
       setIsRoomCardClicked(true);
       setIsWithFriendsCardClicked(false);
-      setIDRoom(nanoid());
+      setIDRoom(nanoid(4));
     } else {
       setIsWithFriendsCardClicked(false);
       setIsRoomCardClicked(false);

--- a/packages/client/src/pages/ForumPage/ForumMessagesListPage.tsx
+++ b/packages/client/src/pages/ForumPage/ForumMessagesListPage.tsx
@@ -38,7 +38,7 @@ export const ForumMessagesListPage: React.FC = () => {
   };
 
   return (
-    <Container maxWidth="md">
+    <Container maxWidth="md" data-testid="page-forum-messages">
       <main className={styles.ForumPage}>
         <div className={styles.ForumPage_wrapper}>
           <div className={stylesMessageItem.MessageItem__user}>

--- a/packages/client/src/pages/ForumPage/ForumThemesListPage.tsx
+++ b/packages/client/src/pages/ForumPage/ForumThemesListPage.tsx
@@ -26,7 +26,7 @@ export const ForumThemesListPage: React.FC = () => {
   };
 
   return (
-    <Container maxWidth="md">
+    <Container maxWidth="md" data-testid="page-forum-main">
       <main className={styles.ForumPage}>
         <h2 className={styles.ForumPage__header}>Форум</h2>
 

--- a/packages/client/src/pages/HomePage/HomePage.tsx
+++ b/packages/client/src/pages/HomePage/HomePage.tsx
@@ -50,7 +50,7 @@ const AdvantagesItem: React.FC<React.PropsWithChildren> = ({ children }) => {
 export const HomePage = () => {
   return (
     <>
-      <section className={styles.promo}>
+      <section className={styles.promo} data-testid="page-home">
         <div className={styles.promo__bg}>
           <Picture webp={promoBgWebp}>
             <img src={promoBg} alt="Карты на столе" />

--- a/packages/client/src/pages/LiderboardPage/LiderboardPage.tsx
+++ b/packages/client/src/pages/LiderboardPage/LiderboardPage.tsx
@@ -11,7 +11,7 @@ export const LiderboardPage = () => {
   };
 
   return (
-    <div className={styles.root}>
+    <div className={styles.root} data-testid="page-leaderboard">
       <Container maxWidth="md">
         <Typography variant="h4" component="h1" align="center" marginBottom={3}>
           Список лидеров

--- a/packages/client/src/pages/LoginPage/LoginPage.tsx
+++ b/packages/client/src/pages/LoginPage/LoginPage.tsx
@@ -45,7 +45,7 @@ export const LoginPage = () => {
   };
 
   return (
-    <div className={styles.root}>
+    <div className={styles.root} data-testid="page-login">
       <Container maxWidth="md">
         <Typography variant="h4" component="h1" align="center" marginBottom={3}>
           Вход

--- a/packages/client/src/pages/ProfilePage/ProfilePage.tsx
+++ b/packages/client/src/pages/ProfilePage/ProfilePage.tsx
@@ -82,7 +82,7 @@ export const ProfilePage: React.FC = () => {
     dispatch(userThunks.changeUserProfile(formData));
   };
   return (
-    <main className={styles.profile}>
+    <main className={styles.profile} data-testid="page-profile">
       <Container maxWidth="md">
         <section className={styles.profile__photo}>
           <Avatar

--- a/packages/client/src/pages/ProfilePage/ProfilePage.tsx
+++ b/packages/client/src/pages/ProfilePage/ProfilePage.tsx
@@ -86,7 +86,7 @@ export const ProfilePage: React.FC = () => {
       <Container maxWidth="md">
         <section className={styles.profile__photo}>
           <Avatar
-            src={`${import.meta.env.VITE_API_ENDPOINT}/resources${user?.avatar}`}
+            src={`${__API_ENDPOINT__}/resources${user?.avatar}`}
             sx={{ width: 100, height: 100 }}
           />
           <div className={styles.profile__photo_edit}>

--- a/packages/client/src/pages/RegisterPage/RegisterPage.tsx
+++ b/packages/client/src/pages/RegisterPage/RegisterPage.tsx
@@ -65,7 +65,7 @@ export const RegisterPage = () => {
   const passwordRef = useRef<HTMLInputElement>();
 
   return (
-    <div className={styles.root}>
+    <div className={styles.root} data-testid="page-register">
       <Container maxWidth="md">
         <Typography variant="h4" component="h1" align="center" marginBottom={3}>
           Регистрация

--- a/packages/client/src/pages/RulesPage/RulesPage.tsx
+++ b/packages/client/src/pages/RulesPage/RulesPage.tsx
@@ -16,7 +16,7 @@ export const RulesPage = () => {
   }, []);
 
   return (
-    <div className={styles.root}>
+    <div className={styles.root} data-testid="page-rules">
       <Container maxWidth="md">
         <section className={styles.parallax}>
           <div

--- a/packages/client/src/services/api/apiRequest.ts
+++ b/packages/client/src/services/api/apiRequest.ts
@@ -10,7 +10,7 @@ export class ApiError extends Error {
 }
 
 const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_ENDPOINT,
+  baseURL: __API_ENDPOINT__,
   withCredentials: true,
 });
 

--- a/packages/client/src/services/slices/__tests__/auth-slice.test.ts
+++ b/packages/client/src/services/slices/__tests__/auth-slice.test.ts
@@ -1,49 +1,107 @@
-import { authSlice, initialState } from "../auth-slice";
+import { mainUser } from "__tests__/fixtures";
+import { delay, withoutMetaKey } from "__tests__/utils";
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
 
-describe("AUTH reducer", () => {
+import { transformUser } from "services/api/transformers";
+
+import { authSlice, authThunks, initialState } from "../auth-slice";
+
+describe("AUTH slice", () => {
   it("should return the initial state", () => {
     expect(authSlice.reducer(undefined, { type: "_" })).toEqual(initialState);
   });
 
-  // it("should handle request", () => {
-  //   expect(reducer(undefined, slice.setRequest)).toEqual({
-  //     ...initialState,
-  //     loading: true,
-  //     error: false,
-  //   });
-  // });
+  it("should handle resetError", () => {
+    const state: typeof initialState = {
+      ...initialState,
+      error: "test error",
+    };
 
-  // it("should handle success", () => {
-  //   expect(
-  //     reducer(
-  //       undefined,
-  //       slice.setSuccess({ success: true, user: { name: "Mary", email: "Mary@gmail.com" } })
-  //     )
-  //   ).toEqual({
-  //     ...initialState,
-  //     loading: false,
-  //     user: { name: "Mary", email: "Mary@gmail.com" },
-  //   });
-  // });
+    expect(authSlice.reducer(state, authSlice.actions.resetError())).toEqual({
+      ...state,
+      error: null,
+    });
+  });
 
-  // it("should handle status", () => {
-  //   const initialState: typeof initialState = {
-  //     ...initialState,
-  //     status: EAuthStatus.pending,
-  //   };
+  it("should handle setUser", () => {
+    const state: typeof initialState = {
+      ...initialState,
+      user: null,
+    };
 
-  //   expect(reducer(initialState, slice.setStatus(EAuthStatus.ok))).toEqual({
-  //     ...initialState,
-  //     status: EAuthStatus.ok,
-  //   });
-  // });
+    expect(
+      authSlice.reducer(state, authSlice.actions.setUser({ name: "Mary", email: "Mary@gmail.com" }))
+    ).toEqual({
+      ...state,
+      user: { name: "Mary", email: "Mary@gmail.com" },
+    });
+  });
 
-  // it("should handle error", () => {
-  //   expect(reducer(undefined, slice.setError("Test error"))).toEqual({
-  //     ...initialState,
-  //     user: null,
-  //     loading: false,
-  //     error: "Test error",
-  //   });
-  // });
+  it("should handle authThunks.me and set user", async () => {
+    const middlewares = [thunk];
+    const mockStore = configureMockStore(middlewares);
+    const store = mockStore({ ...initialState });
+    const expectedActions = [
+      authThunks.me.pending("requestId", undefined),
+      authThunks.me.fulfilled({ ...transformUser(mainUser) }, "requestId", undefined),
+    ];
+
+    await store.dispatch(authThunks.me() as never);
+    const evaluatedActions = store.getActions();
+
+    expect(withoutMetaKey(evaluatedActions)).toEqual(withoutMetaKey(expectedActions));
+  });
+
+  it("should handle authThunks.login and set user", async () => {
+    const middlewares = [thunk];
+    const mockStore = configureMockStore(middlewares);
+    const store = mockStore({ ...initialState });
+    const loginRequestData = { login: "valid", password: "valid" };
+    const expectedActions = [
+      authThunks.login.pending("requestId", loginRequestData),
+      authThunks.me.pending("requestId", undefined),
+      authThunks.login.fulfilled(undefined, "requestId", loginRequestData),
+      authThunks.me.fulfilled({ ...transformUser(mainUser) }, "requestId", undefined),
+    ];
+
+    await store.dispatch(authThunks.login(loginRequestData) as never);
+    // После логина в authThunks.login срабатывает authThunks.me
+    // Задержка позволяет authThunks.me завершиться
+    await delay(100);
+    const evaluatedActions = store.getActions();
+
+    expect(withoutMetaKey(evaluatedActions)).toEqual(withoutMetaKey(expectedActions));
+  });
+
+  it("should handle authThunks.login and set error", async () => {
+    const middlewares = [thunk];
+    const mockStore = configureMockStore(middlewares);
+    const store = mockStore({ ...initialState });
+    const loginRequestData = { login: "invalid", password: "invalid" };
+    const expectedActions = [
+      authThunks.login.pending("requestId", loginRequestData),
+      authThunks.login.rejected(null, "requestId", loginRequestData),
+    ];
+
+    await store.dispatch(authThunks.login(loginRequestData) as never);
+    const evaluatedActions = store.getActions();
+
+    expect(withoutMetaKey(evaluatedActions)).toEqual(withoutMetaKey(expectedActions));
+  });
+
+  it("should handle authThunks.logout and reset user", async () => {
+    const middlewares = [thunk];
+    const mockStore = configureMockStore(middlewares);
+    const store = mockStore({ ...initialState, user: transformUser(mainUser) });
+    const expectedActions = [
+      authThunks.logout.pending("requestId", undefined),
+      authThunks.logout.fulfilled("OK", "requestId", undefined),
+    ];
+
+    await store.dispatch(authThunks.logout() as never);
+    const evaluatedActions = store.getActions();
+
+    expect(withoutMetaKey(evaluatedActions)).toEqual(withoutMetaKey(expectedActions));
+  });
 });

--- a/packages/client/src/services/slices/__tests__/auth-slice.test.ts
+++ b/packages/client/src/services/slices/__tests__/auth-slice.test.ts
@@ -1,0 +1,49 @@
+import { authSlice, initialState } from "../auth-slice";
+
+describe("AUTH reducer", () => {
+  it("should return the initial state", () => {
+    expect(authSlice.reducer(undefined, { type: "_" })).toEqual(initialState);
+  });
+
+  // it("should handle request", () => {
+  //   expect(reducer(undefined, slice.setRequest)).toEqual({
+  //     ...initialState,
+  //     loading: true,
+  //     error: false,
+  //   });
+  // });
+
+  // it("should handle success", () => {
+  //   expect(
+  //     reducer(
+  //       undefined,
+  //       slice.setSuccess({ success: true, user: { name: "Mary", email: "Mary@gmail.com" } })
+  //     )
+  //   ).toEqual({
+  //     ...initialState,
+  //     loading: false,
+  //     user: { name: "Mary", email: "Mary@gmail.com" },
+  //   });
+  // });
+
+  // it("should handle status", () => {
+  //   const initialState: typeof initialState = {
+  //     ...initialState,
+  //     status: EAuthStatus.pending,
+  //   };
+
+  //   expect(reducer(initialState, slice.setStatus(EAuthStatus.ok))).toEqual({
+  //     ...initialState,
+  //     status: EAuthStatus.ok,
+  //   });
+  // });
+
+  // it("should handle error", () => {
+  //   expect(reducer(undefined, slice.setError("Test error"))).toEqual({
+  //     ...initialState,
+  //     user: null,
+  //     loading: false,
+  //     error: "Test error",
+  //   });
+  // });
+});

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
   },
   define: {
     __SERVER_PORT__: process.env.SERVER_PORT,
+    __API_ENDPOINT__: JSON.stringify(process.env.API_ENDPOINT),
   },
   plugins: [react(), imagetools()],
   build: {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,6 +8,7 @@
     "dev": "cross-env NODE_ENV=development nodemon index.ts",
     "lint": "eslint .",
     "format": "prettier --write .",
+    "test:watch": "npm run test -- --watch",
     "test": "jest ."
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1716,6 +1716,28 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
+"@mswjs/cookies@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.2.2.tgz#b4e207bf6989e5d5427539c2443380a33ebb922b"
+  integrity sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.0"
+    set-cookie-parser "^2.4.6"
+
+"@mswjs/interceptors@^0.17.5":
+  version "0.17.9"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.17.9.tgz#0096fc88fea63ee42e36836acae8f4ae33651c04"
+  integrity sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    "@types/debug" "^4.1.7"
+    "@xmldom/xmldom" "^0.8.3"
+    debug "^4.3.3"
+    headers-polyfill "^3.1.0"
+    outvariant "^1.2.1"
+    strict-event-emitter "^0.2.4"
+    web-encoding "^1.1.5"
+
 "@mui/base@5.0.0-alpha.118":
   version "5.0.0-alpha.118"
   resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.118.tgz#335e7496ea605c9b7bda4164efb2da3f09f36dfc"
@@ -2084,6 +2106,11 @@
   dependencies:
     "@octokit/openapi-types" "^13.4.0"
 
+"@open-draft/until@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
+
 "@parcel/watcher@2.0.4":
   version "2.0.4"
   resolved "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.4.tgz"
@@ -2241,10 +2268,22 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
 "@types/cors@^2.8.12":
   version "2.8.12"
   resolved "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz"
   integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
+
+"@types/debug@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
 
 "@types/estree@^1.0.0":
   version "1.0.0"
@@ -2312,6 +2351,11 @@
     expect "^28.0.0"
     pretty-format "^28.0.0"
 
+"@types/js-levenshtein@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz#ba05426a43f9e4e30b631941e0aa17bf0c890ed5"
+  integrity sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==
+
 "@types/jsdom@^20.0.0":
   version "20.0.0"
   resolved "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.0.tgz"
@@ -2345,6 +2389,11 @@
   version "1.2.2"
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*":
   version "18.7.13"
@@ -2420,6 +2469,13 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/redux-mock-store@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/redux-mock-store/-/redux-mock-store-1.0.3.tgz#895de4a364bc4836661570aec82f2eef5989d1fb"
+  integrity sha512-Wqe3tJa6x9MxMN4DJnMfZoBRBRak1XTPklqj4qkVm5VBpZnC8PSADf4kLuFQ9NAdHaowfWoEeUMz7NWc2GMtnA==
+  dependencies:
+    redux "^4.0.5"
+
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz"
@@ -2431,6 +2487,13 @@
   integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
   dependencies:
     "@types/mime" "*"
+    "@types/node" "*"
+
+"@types/set-cookie-parser@^2.4.0":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz#b6a955219b54151bfebd4521170723df5e13caad"
+  integrity sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==
+  dependencies:
     "@types/node" "*"
 
 "@types/stack-utils@^2.0.0":
@@ -2552,6 +2615,16 @@
     "@babel/plugin-transform-react-jsx-source" "^7.18.6"
     magic-string "^0.26.2"
     react-refresh "^0.14.0"
+
+"@xmldom/xmldom@^0.8.3":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.6.tgz#8a1524eb5bd5e965c1e3735476f0262469f71440"
+  integrity sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==
+
+"@zxing/text-encoding@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
+  integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -3128,6 +3201,14 @@ chalk@4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
@@ -3155,7 +3236,7 @@ chardet@^0.7.0:
   resolved "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.5.1, chokidar@^3.5.2:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.2, chokidar@^3.5.1, chokidar@^3.5.2:
   version "3.5.3"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -3514,6 +3595,11 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookie@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -4312,6 +4398,11 @@ eventemitter3@^4.0.4:
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
@@ -4906,6 +4997,11 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
+"graphql@^15.0.0 || ^16.0.0":
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
+
 handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz"
@@ -4973,6 +5069,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+headers-polyfill@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.1.2.tgz#9a4dcb545c5b95d9569592ef7ec0708aab763fbe"
+  integrity sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==
 
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
@@ -5194,6 +5295,27 @@ init-package-json@^3.0.2:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^4.0.0"
 
+inquirer@^8.2.0:
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
+  integrity sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^7.0.0"
+
 inquirer@^8.2.4:
   version "8.2.4"
   resolved "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz"
@@ -5233,6 +5355,14 @@ ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+is-arguments@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
 
 is-array-buffer@^3.0.1:
   version "3.0.1"
@@ -5321,6 +5451,13 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-generator-function@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
@@ -5342,6 +5479,11 @@ is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
+
+is-node-process@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.0.1.tgz#4fc7ac3a91e8aac58175fe0578abbc56f2831b23"
+  integrity sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==
 
 is-number-object@^1.0.4:
   version "1.0.7"
@@ -5435,7 +5577,7 @@ is-text-path@^1.0.1:
   dependencies:
     text-extensions "^1.0.0"
 
-is-typed-array@^1.1.10, is-typed-array@^1.1.9:
+is-typed-array@^1.1.10, is-typed-array@^1.1.3, is-typed-array@^1.1.9:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
   integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
@@ -5975,6 +6117,11 @@ jest@^28:
     "@jest/types" "^28.1.3"
     import-local "^3.0.2"
     jest-cli "^28.1.3"
+
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -6705,6 +6852,31 @@ ms@2.1.3, ms@^2.0.0:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-1.2.0.tgz#5337ed96cbd6582d2675403950e7d97333d4c43d"
+  integrity sha512-2nbGxmG8Zk/eCiWCAFtgz5kwPE5YnTlOcRBggFkykqkBSPQE+kvlHJElOzrTG21Tb0ZGXWgn0PI5kyANnOpgug==
+  dependencies:
+    "@mswjs/cookies" "^0.2.2"
+    "@mswjs/interceptors" "^0.17.5"
+    "@open-draft/until" "^1.0.3"
+    "@types/cookie" "^0.4.1"
+    "@types/js-levenshtein" "^1.1.1"
+    chalk "4.1.1"
+    chokidar "^3.4.2"
+    cookie "^0.4.2"
+    graphql "^15.0.0 || ^16.0.0"
+    headers-polyfill "^3.1.0"
+    inquirer "^8.2.0"
+    is-node-process "^1.0.1"
+    js-levenshtein "^1.1.6"
+    node-fetch "^2.6.7"
+    outvariant "^1.3.0"
+    path-to-regexp "^6.2.0"
+    strict-event-emitter "^0.4.3"
+    type-fest "^2.19.0"
+    yargs "^17.3.1"
+
 multimatch@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz"
@@ -7136,6 +7308,11 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
+outvariant@^1.2.1, outvariant@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.3.0.tgz#c39723b1d2cba729c930b74bf962317a81b9b1c9"
+  integrity sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
@@ -7366,6 +7543,11 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
   integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
+
+path-to-regexp@^6.2.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
+  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -7975,12 +8157,19 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-mock-store@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.4.tgz#90d02495fd918ddbaa96b83aef626287c9ab5872"
+  integrity sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==
+  dependencies:
+    lodash.isplainobject "^4.0.6"
+
 redux-thunk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.2.tgz#b9d05d11994b99f7a91ea223e8b04cf0afa5ef3b"
   integrity sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==
 
-redux@^4.2.0:
+redux@^4.0.5, redux@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
   integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
@@ -8237,6 +8426,11 @@ set-blocking@^2.0.0:
   resolved "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
+set-cookie-parser@^2.4.6:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz#131921e50f62ff1a66a461d7d62d7b21d5d15a51"
+  integrity sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==
+
 setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
@@ -8485,6 +8679,18 @@ statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+strict-event-emitter@^0.2.4:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz#b4e768927c67273c14c13d20e19d5e6c934b47ca"
+  integrity sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==
+  dependencies:
+    events "^3.3.0"
+
+strict-event-emitter@^0.4.3:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz#ff347c8162b3e931e3ff5f02cfce6772c3b07eb3"
+  integrity sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -9058,6 +9264,11 @@ type-fest@^0.8.1:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"
@@ -9189,6 +9400,17 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+util@^0.12.3:
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
+  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    which-typed-array "^1.1.2"
+
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
@@ -9298,6 +9520,15 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+web-encoding@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.5.tgz#fc810cf7667364a6335c939913f5051d3e0c4864"
+  integrity sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==
+  dependencies:
+    util "^0.12.3"
+  optionalDependencies:
+    "@zxing/text-encoding" "0.9.0"
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
@@ -9361,7 +9592,7 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
-which-typed-array@^1.1.9:
+which-typed-array@^1.1.2, which-typed-array@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
   integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,6 +2190,11 @@
     "@testing-library/dom" "^8.5.0"
     "@types/react-dom" "^18.0.0"
 
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz"
@@ -5019,6 +5024,11 @@ hard-rejection@^2.1.0:
   resolved "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
+harmony-reflect@^1.4.6:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
+  integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -5183,6 +5193,13 @@ iconv-lite@0.6.3, iconv-lite@^0.6.2:
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.13:
   version "1.2.1"


### PR DESCRIPTION
### Какую задачу решаем

- env переменная `VITE_API_ENDPOINT` переименована в `API_ENDPOINT` (нужно добавить на хостинге)
- настроен jest
- для  `auth-slice` добавлены тесты синхронных и асинхронных экшонов
- для `App` добавлены проверки перехода на страницы при клике по ссылкам навигационного меню
- добавлены тесты для `ErrorBoundary`
- на `ci` добавлено создание файла `.env`

В задепплоенной версии пользователь не отображается, т.к.  `VITE_API_ENDPOINT` была переименована и ломаются запросы к API. Починится, когда на хостинге исправим/добавим. Вообще это конечно баг, так быть не должно, нужна валидация ответа от API. Добавил todo на исправление в тасктрекер.