### PR TITLE
fix(23UG-72): добавляет валидацию ответа от api

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,7 +33,8 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.4",
     "react-redux": "^8.0.5",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "^6.8.1",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@testing-library/react": "^13.3.0",

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -26,3 +26,5 @@ export const ROUTES = {
     path: "/game",
   },
 };
+
+export const SCHEMA_ERROR_MESSAGE = "Schema response is not valid";

--- a/packages/client/src/services/api/__tests__/authApi.test.ts
+++ b/packages/client/src/services/api/__tests__/authApi.test.ts
@@ -1,0 +1,31 @@
+import { requestUrl, server } from "__tests__/api-mock";
+import { mainUser } from "__tests__/fixtures";
+import { rest } from "msw";
+
+import { SCHEMA_ERROR_MESSAGE } from "../../../constants";
+import { authAPI } from "../authApi";
+import { transformUser } from "../transformers";
+
+describe("authAPI", () => {
+  it("should authAPI.me return User", async () => {
+    server.use(
+      rest.get(requestUrl("auth/user"), (_req, res, ctx) =>
+        res.once(ctx.status(200), ctx.json(mainUser))
+      )
+    );
+
+    const result = await authAPI.me();
+
+    expect(result).toEqual(transformUser(mainUser));
+  });
+
+  it("should throw an error when authAPI.me doesn't return a UserDTO", async () => {
+    server.use(
+      rest.get(requestUrl("auth/user"), (_req, res, ctx) => res.once(ctx.status(200), ctx.json({})))
+    );
+
+    await expect(async () => {
+      await authAPI.me();
+    }).rejects.toThrow(SCHEMA_ERROR_MESSAGE);
+  });
+});

--- a/packages/client/src/services/api/__tests__/userApi.test.ts
+++ b/packages/client/src/services/api/__tests__/userApi.test.ts
@@ -1,0 +1,57 @@
+import { requestUrl, server } from "__tests__/api-mock";
+import { mainUser } from "__tests__/fixtures";
+import { rest } from "msw";
+
+import { SCHEMA_ERROR_MESSAGE } from "../../../constants";
+import { transformUser } from "../transformers";
+import { userAPI } from "../userApi";
+
+describe("userAPI", () => {
+  it("should userAPI.changeUserAvatar return User", async () => {
+    server.use(
+      rest.put(requestUrl("user/profile/avatar"), (_req, res, ctx) =>
+        res.once(ctx.status(200), ctx.json(mainUser))
+      )
+    );
+
+    const result = await userAPI.changeUserAvatar(new FormData());
+
+    expect(result).toEqual(transformUser(mainUser));
+  });
+
+  it("should userAPI.changeUserProfile return User", async () => {
+    server.use(
+      rest.put(requestUrl("user/profile"), (_req, res, ctx) =>
+        res.once(ctx.status(200), ctx.json(mainUser))
+      )
+    );
+
+    const result = await userAPI.changeUserProfile(mainUser);
+
+    expect(result).toEqual(transformUser(mainUser));
+  });
+
+  it("should throw an error when userAPI.changeUserAvatar doesn't return a UserDTO", async () => {
+    server.use(
+      rest.put(requestUrl("user/profile/avatar"), (_req, res, ctx) =>
+        res.once(ctx.status(200), ctx.json({}))
+      )
+    );
+
+    await expect(async () => {
+      await userAPI.changeUserAvatar(new FormData());
+    }).rejects.toThrow(SCHEMA_ERROR_MESSAGE);
+  });
+
+  it("should throw an error when userAPI.changeUserProfile doesn't return a UserDTO", async () => {
+    server.use(
+      rest.put(requestUrl("user/profile"), (_req, res, ctx) =>
+        res.once(ctx.status(200), ctx.json({}))
+      )
+    );
+
+    await expect(async () => {
+      await userAPI.changeUserProfile(mainUser);
+    }).rejects.toThrow(SCHEMA_ERROR_MESSAGE);
+  });
+});

--- a/packages/client/src/services/api/authApi.ts
+++ b/packages/client/src/services/api/authApi.ts
@@ -1,4 +1,7 @@
+import { parseSchema } from "utils/parseSchema";
+
 import { request } from "./apiRequest";
+import { apiSchema } from "./schema";
 import { transformUser } from "./transformers";
 import { LoginRequestData, RegisterRequestData, User, UserDTO } from "./types";
 
@@ -8,6 +11,8 @@ export const authAPI = {
 
   me: async (): Promise<User> => {
     const result = await request.get<UserDTO>("auth/user");
+
+    parseSchema(apiSchema.UserDTO, result);
 
     return transformUser(result);
   },

--- a/packages/client/src/services/api/schema.ts
+++ b/packages/client/src/services/api/schema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+const UserDTO = z.object({
+  id: z.number(),
+  login: z.string(),
+  first_name: z.string(),
+  second_name: z.string(),
+  display_name: z.string(),
+  avatar: z.string(),
+  phone: z.string(),
+  email: z.string(),
+});
+
+export const apiSchema = { UserDTO };

--- a/packages/client/src/services/api/types.ts
+++ b/packages/client/src/services/api/types.ts
@@ -1,3 +1,7 @@
+import { z } from "zod";
+
+import { apiSchema } from "./schema";
+
 export type APIError = {
   reason: string;
   status?: number;
@@ -26,16 +30,7 @@ export type UpdateUserRequestData = {
   phone: string;
 };
 
-export type UserDTO = {
-  id: number;
-  login: string;
-  first_name: string;
-  second_name: string;
-  display_name: string;
-  avatar: string;
-  phone: string;
-  email: string;
-};
+export type UserDTO = z.infer<typeof apiSchema.UserDTO>;
 
 export type User = {
   id: number;

--- a/packages/client/src/services/api/userApi.ts
+++ b/packages/client/src/services/api/userApi.ts
@@ -1,14 +1,23 @@
+import { parseSchema } from "utils/parseSchema";
+
 import { request } from "./apiRequest";
+import { apiSchema } from "./schema";
 import { transformUser } from "./transformers";
 import { UpdateUserRequestData, User, UserDTO } from "./types";
 
 export const userAPI = {
   changeUserAvatar: async (data: FormData): Promise<User> => {
     const result = await request.put<UserDTO, FormData>("user/profile/avatar", data);
+
+    parseSchema(apiSchema.UserDTO, result);
+
     return transformUser(result);
   },
   changeUserProfile: async (data: UpdateUserRequestData): Promise<User> => {
     const result = await request.put<UserDTO, UpdateUserRequestData>("user/profile", data);
+
+    parseSchema(apiSchema.UserDTO, result);
+
     return transformUser(result);
   },
 };

--- a/packages/client/src/utils/parseSchema.ts
+++ b/packages/client/src/utils/parseSchema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+import { SCHEMA_ERROR_MESSAGE } from "../constants";
+
+export const parseSchema = (schema: ReturnType<typeof z.object>, data: unknown) => {
+  try {
+    const result = schema.parse(data);
+
+    return result;
+  } catch {
+    throw new Error(SCHEMA_ERROR_MESSAGE);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9837,3 +9837,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
### Какую задачу решаем

У нас базовый путь до api берется из env переменной. Если по каким-то причинам ее нет, путь превращается в origin + apiEndpoint. На сервере настроены редиректы со всех страниц на /, т.к. это SPA. Получается запрос origin + apiEndpoint возвращается со статусом 200 но без пользователя. Попадает в трансформер, в котором поля пользователя заполняются undefined и дальше все идет по сценарию, как будто прошли аутентификацию.

Текущий PR фиксит эту проблему, добавляя проверку схемы ответа с помощью [zod](https://zod.dev/)