### PR TITLE
feat(23UG-40): реализует OAuth через яндекс id

### DIFF
--- a/packages/client/src/components/app/App.test.tsx
+++ b/packages/client/src/components/app/App.test.tsx
@@ -43,7 +43,7 @@ describe("Components/App", () => {
       preloadedState: { auth: { ...authInitialState } },
     });
 
-    await user.click(screen.getByText("Нет аккаунта?"));
+    await user.click(screen.getByText("Регистрация"));
 
     expect(screen.getByTestId("page-register")).toBeDefined();
   });

--- a/packages/client/src/components/app/App.tsx
+++ b/packages/client/src/components/app/App.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from "react";
-import { Route, Routes, useLocation } from "react-router-dom";
+import { Route, Routes, useLocation, useSearchParams } from "react-router-dom";
 
 import { useDispatch, useSelector } from "services/hooks";
 import { authSelect, authThunks } from "services/slices/auth-slice";
+import { oAuthThunks } from "services/slices/oauth-slice";
 import { Theme } from "theme/ThemeContext";
 import { useTheme } from "theme/useTheme";
 import { toggleFullScreen } from "utils/toggleFullScreen";
@@ -31,6 +32,15 @@ function App() {
   const { user } = useSelector(authSelect);
   const { theme } = useTheme();
   const location = useLocation();
+  const [params] = useSearchParams();
+
+  useEffect(() => {
+    const code = params.get("code");
+
+    if (code) {
+      dispatch(oAuthThunks.login(code));
+    }
+  }, [params]);
 
   useEffect(() => {
     if (!user) {

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -28,3 +28,5 @@ export const ROUTES = {
 };
 
 export const SCHEMA_ERROR_MESSAGE = "Schema response is not valid";
+
+export const IS_SSR = typeof window === "undefined";

--- a/packages/client/src/pages/LoginPage/LoginPage.tsx
+++ b/packages/client/src/pages/LoginPage/LoginPage.tsx
@@ -5,6 +5,7 @@ import { Controller, SubmitHandler, useForm } from "react-hook-form";
 
 import { useDispatch, useSelector } from "services/hooks";
 import { authSelect, authSlice, authThunks } from "services/slices/auth-slice";
+import { oAuthSelect, oAuthSlice, oAuthThunks } from "services/slices/oauth-slice";
 import { InputNames, REQUIRED_MESSAGE, validationTemplate } from "utils/validation/validation";
 
 import { ROUTES } from "../../constants";
@@ -19,7 +20,8 @@ type TFormInput = {
 export const LoginPage = () => {
   const dispatch = useDispatch();
   const { error: authError, loading } = useSelector(authSelect);
-  const [authErrorLocal, setAuthErrorLocal] = useState(authError);
+  const { error: oAuthError, loading: oAuthLoading } = useSelector(oAuthSelect);
+  const [authErrorLocal, setAuthErrorLocal] = useState(authError || oAuthError);
   const {
     control,
     handleSubmit,
@@ -39,6 +41,13 @@ export const LoginPage = () => {
     }
   }, [dispatch, authError, setAuthErrorLocal]);
 
+  useEffect(() => {
+    if (oAuthError) {
+      setAuthErrorLocal(oAuthError);
+      dispatch(oAuthSlice.actions.resetError());
+    }
+  }, [dispatch, oAuthError, setAuthErrorLocal]);
+
   const onSubmit: SubmitHandler<TFormInput> = async (data) => {
     authErrorLocal && setAuthErrorLocal(null);
     dispatch(authThunks.login(data));
@@ -46,8 +55,7 @@ export const LoginPage = () => {
 
   const handleLoginWithYandex = async (event: React.MouseEvent) => {
     event.preventDefault();
-
-    console.log(event);
+    dispatch(oAuthThunks.getServiceId());
   };
 
   return (
@@ -95,7 +103,7 @@ export const LoginPage = () => {
               )}
             />
           </Stack>
-          {loading && (
+          {(loading || oAuthLoading) && (
             <Box mt={2} textAlign={"center"}>
               ...Loading
             </Box>

--- a/packages/client/src/pages/LoginPage/LoginPage.tsx
+++ b/packages/client/src/pages/LoginPage/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Container, Link, Stack, TextField, Typography } from "@mui/material";
 
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
 
 import { useDispatch, useSelector } from "services/hooks";
@@ -42,6 +42,12 @@ export const LoginPage = () => {
   const onSubmit: SubmitHandler<TFormInput> = async (data) => {
     authErrorLocal && setAuthErrorLocal(null);
     dispatch(authThunks.login(data));
+  };
+
+  const handleLoginWithYandex = async (event: React.MouseEvent) => {
+    event.preventDefault();
+
+    console.log(event);
   };
 
   return (
@@ -113,10 +119,30 @@ export const LoginPage = () => {
           >
             Войти
           </Button>
+          <Button
+            fullWidth={true}
+            size="large"
+            type="button"
+            variant="contained"
+            color="warning"
+            onClick={handleLoginWithYandex}
+            sx={{
+              marginTop: "20px",
+              marginBottom: "10px",
+            }}
+          >
+            Войти с Яндекс ID
+          </Button>
         </form>
         <Link href={ROUTES.signUp.path} underline="none">
-          <Typography align="center" fontSize="16px" color="text.disabled" fontWeight="bold">
-            Нет аккаунта?
+          <Typography
+            align="center"
+            fontSize="16px"
+            color="text.disabled"
+            fontWeight="bold"
+            mt="20px"
+          >
+            Регистрация
           </Typography>
         </Link>
       </Container>

--- a/packages/client/src/pages/ProfilePage/ProfilePage.tsx
+++ b/packages/client/src/pages/ProfilePage/ProfilePage.tsx
@@ -229,6 +229,7 @@ export const ProfilePage: React.FC = () => {
                   variant="standard"
                   label="Фамилия"
                   id="second_name"
+                  value={field.value}
                   InputLabelProps={{ shrink: false }}
                   onChange={field.onChange}
                   onInput={() => setIsInputChanged(true)}

--- a/packages/client/src/services/api/OAuthApi.ts
+++ b/packages/client/src/services/api/OAuthApi.ts
@@ -1,0 +1,10 @@
+import { request } from "./apiRequest";
+import { OAuthLoginRequestData, OAuthServiceRequestData, OAuthServiceResponse } from "./types";
+
+export const OAauthAPI = {
+  getServiceId: (data: OAuthServiceRequestData): Promise<OAuthServiceResponse> =>
+    request.get<OAuthServiceResponse>("oauth/yandex/service-id", { params: data }),
+
+  login: (data: OAuthLoginRequestData): Promise<"OK"> =>
+    request.post<"OK", OAuthLoginRequestData>("oauth/yandex", data),
+};

--- a/packages/client/src/services/api/__tests__/authApi.test.ts
+++ b/packages/client/src/services/api/__tests__/authApi.test.ts
@@ -19,6 +19,24 @@ describe("authAPI", () => {
     expect(result).toEqual(transformUser(mainUser));
   });
 
+  it("should authAPI.me return User if User has nullable fields", async () => {
+    const stubUser = {
+      ...mainUser,
+      avatar: null,
+      display_name: null,
+      phone: null,
+    };
+    server.use(
+      rest.get(requestUrl("auth/user"), (_req, res, ctx) =>
+        res.once(ctx.status(200), ctx.json(stubUser))
+      )
+    );
+
+    const result = await authAPI.me();
+
+    expect(result).toEqual(transformUser(stubUser));
+  });
+
   it("should throw an error when authAPI.me doesn't return a UserDTO", async () => {
     server.use(
       rest.get(requestUrl("auth/user"), (_req, res, ctx) => res.once(ctx.status(200), ctx.json({})))

--- a/packages/client/src/services/api/__tests__/userApi.test.ts
+++ b/packages/client/src/services/api/__tests__/userApi.test.ts
@@ -20,15 +20,20 @@ describe("userAPI", () => {
   });
 
   it("should userAPI.changeUserProfile return User", async () => {
+    const stubUser = {
+      ...mainUser,
+      display_name: "Вася Василек",
+      phone: "89137909090",
+    };
     server.use(
       rest.put(requestUrl("user/profile"), (_req, res, ctx) =>
-        res.once(ctx.status(200), ctx.json(mainUser))
+        res.once(ctx.status(200), ctx.json(stubUser))
       )
     );
 
-    const result = await userAPI.changeUserProfile(mainUser);
+    const result = await userAPI.changeUserProfile(stubUser);
 
-    expect(result).toEqual(transformUser(mainUser));
+    expect(result).toEqual(transformUser(stubUser));
   });
 
   it("should throw an error when userAPI.changeUserAvatar doesn't return a UserDTO", async () => {
@@ -44,6 +49,11 @@ describe("userAPI", () => {
   });
 
   it("should throw an error when userAPI.changeUserProfile doesn't return a UserDTO", async () => {
+    const stubUser = {
+      ...mainUser,
+      display_name: "Вася Василек",
+      phone: "89137909090",
+    };
     server.use(
       rest.put(requestUrl("user/profile"), (_req, res, ctx) =>
         res.once(ctx.status(200), ctx.json({}))
@@ -51,7 +61,7 @@ describe("userAPI", () => {
     );
 
     await expect(async () => {
-      await userAPI.changeUserProfile(mainUser);
+      await userAPI.changeUserProfile(stubUser);
     }).rejects.toThrow(SCHEMA_ERROR_MESSAGE);
   });
 });

--- a/packages/client/src/services/api/schema.ts
+++ b/packages/client/src/services/api/schema.ts
@@ -5,9 +5,9 @@ const UserDTO = z.object({
   login: z.string(),
   first_name: z.string(),
   second_name: z.string(),
-  display_name: z.string(),
-  avatar: z.string(),
-  phone: z.string(),
+  display_name: z.string().nullable(),
+  avatar: z.string().nullable(),
+  phone: z.string().nullable(),
   email: z.string(),
 });
 

--- a/packages/client/src/services/api/transformers.ts
+++ b/packages/client/src/services/api/transformers.ts
@@ -6,9 +6,9 @@ export const transformUser = (data: UserDTO): User => {
     login: data.login,
     firstName: data.first_name,
     secondName: data.second_name,
-    displayName: data.display_name,
-    avatar: data.avatar,
-    phone: data.phone,
+    displayName: data.display_name || "",
+    avatar: data.avatar || "",
+    phone: data.phone || "",
     email: data.email,
     fullName: `${data.first_name} ${data.second_name}`,
   };

--- a/packages/client/src/services/api/types.ts
+++ b/packages/client/src/services/api/types.ts
@@ -7,6 +7,19 @@ export type APIError = {
   status?: number;
 };
 
+export type OAuthServiceRequestData = {
+  redirect_uri: string;
+};
+
+export type OAuthServiceResponse = {
+  service_id: string;
+};
+
+export type OAuthLoginRequestData = {
+  code: string;
+  redirect_uri: string;
+};
+
 export type LoginRequestData = {
   login: string;
   password: string;

--- a/packages/client/src/services/reducers.ts
+++ b/packages/client/src/services/reducers.ts
@@ -2,10 +2,12 @@ import { combineReducers } from "redux";
 
 import { authSlice } from "./slices/auth-slice";
 import { gameSlice } from "./slices/gameSlice";
+import { oAuthSlice } from "./slices/oauth-slice";
 import { userSlice } from "./slices/user-slice";
 
 export const rootReducer = combineReducers({
   user: userSlice.reducer,
   auth: authSlice.reducer,
+  oauth: oAuthSlice.reducer,
   game: gameSlice.reducer,
 });

--- a/packages/client/src/services/slices/oauth-slice.ts
+++ b/packages/client/src/services/slices/oauth-slice.ts
@@ -1,0 +1,80 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+
+import { IS_SSR } from "../../constants";
+import { OAauthAPI } from "../api/OAuthApi";
+import { OAuthLoginRequestData } from "../api/types";
+import type { RootState } from "../store";
+
+import { authThunks } from "./auth-slice";
+
+type OAuthState = {
+  loading: boolean;
+  error: string | null;
+};
+
+const getRedirectUri = () => (IS_SSR ? "" : window.location.origin);
+
+const OAUTH_URI_AUTHORIZE = "https://oauth.yandex.ru/authorize?response_type=code";
+// Пока получаем id клиента динамически через API яндекса, берем для redirect_uri текущий домен
+const REDIRECT_URI = getRedirectUri();
+
+export const initialState: OAuthState = {
+  loading: false,
+  error: null,
+};
+
+export const oAuthThunks = {
+  getServiceId: createAsyncThunk("OAUTH/getServiceId", async () => {
+    if (IS_SSR) {
+      return;
+    }
+
+    const { service_id } = await OAauthAPI.getServiceId({
+      redirect_uri: REDIRECT_URI,
+    });
+
+    window.location.replace(
+      `${OAUTH_URI_AUTHORIZE}&client_id=${service_id}&redirect_uri=${REDIRECT_URI}`
+    );
+  }),
+
+  login: createAsyncThunk<
+    void,
+    OAuthLoginRequestData["code"],
+    { rejectValue: OAuthState["error"] }
+  >("OAUTH/login", async (code, { dispatch }) => {
+    if (IS_SSR) {
+      return;
+    }
+
+    await OAauthAPI.login({
+      code,
+      redirect_uri: REDIRECT_URI,
+    });
+
+    dispatch(authThunks.me());
+  }),
+};
+
+export const oAuthSlice = createSlice({
+  name: "OAUTH",
+  initialState,
+  reducers: {
+    resetError(state) {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    // Если getServiceId.fulfilled, то происходит редирект на страницу яндекса для авторизации
+    builder.addCase(oAuthThunks.getServiceId.pending, (state) => {
+      state.loading = true;
+      state.error = null;
+    });
+    builder.addCase(oAuthThunks.getServiceId.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.error?.message || null;
+    });
+  },
+});
+
+export const oAuthSelect = (state: RootState) => state.oauth;


### PR DESCRIPTION
### Какую задачу решаем

- Добавляена OAuth через яндекс id по упрощенной схеме:
  - получаем от предоставленного API `client_id` для текущего домена
  - переходим на страницу яндекс авторизации с полученным `client_id`
  - после авторизации возвращаемся обратно с кодом в `query` параметре
  - авторизуемся через предоставленный API с полученным кодом
- Исправлена ошибка при проверке в рантайме ответа от API с данными пользователя, когда поля `avatar`, `phone` и `display_name` пустые